### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { Component, ErrorInfo, ReactNode } from 'react';
 
 interface Props {
   children: ReactNode;

--- a/client/src/components/MainApp.tsx
+++ b/client/src/components/MainApp.tsx
@@ -106,7 +106,7 @@ const MainApp: React.FC = () => {
     if (item.alternatives && typeof item.alternatives[0] === 'object') {
       const alternativeIds = (item.alternatives as Array<{ uri: string }>)
         .map(alt => alt.uri ? alt.uri.split(':')[2] : null)
-        .filter(Boolean);
+        .filter((id): id is string => Boolean(id));
       trackIds.push(...alternativeIds);
     }
     


### PR DESCRIPTION
Fixes TypeScript compilation errors preventing successful builds:

- Remove unused React import from ErrorBoundary.tsx
- Add proper type guard to filter function in MainApp.tsx to handle string | null types

Fixes #5

Generated with [Claude Code](https://claude.ai/code)