### PR TITLE
fix: Add Sentry error reporting to custom ErrorBoundary

### DIFF
--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
+import * as Sentry from '@sentry/react';
 
 interface Props {
   children: ReactNode;
@@ -21,6 +22,14 @@ class ErrorBoundary extends Component<Props, State> {
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('Uncaught error:', error, errorInfo);
+    
+    // Report the error to Sentry
+    Sentry.withScope((scope) => {
+      scope.setTag('errorBoundary', 'custom');
+      scope.setContext('errorInfo', errorInfo);
+      scope.setLevel('error');
+      Sentry.captureException(error);
+    });
   }
 
   public render() {


### PR DESCRIPTION
Fixes issue where React errors weren't appearing in Sentry logs.

The custom ErrorBoundary was catching errors but not reporting them to Sentry, causing errors to be invisible in monitoring. Now properly captures and reports errors with additional context tags.

Fixes #7

Generated with [Claude Code](https://claude.ai/code)